### PR TITLE
Per user reports

### DIFF
--- a/supabase/schemas/schema.sql
+++ b/supabase/schemas/schema.sql
@@ -576,8 +576,42 @@ BEGIN
         l.seller_id=user_ID
 
     ORDER BY created_at DESC;
-
-
-
 END;
 $$;
+
+
+---------------------------------------------------------------------
+------------ Favorite Flavors ---------------------------------------
+---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION transactions.favorite_flavours(
+    user_ID uuid
+) RETURNS TABLE(
+    product_name VARCHAR(255),
+    product_description TEXT,
+    product_category listings.category_type
+)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN QUERY
+    
+    -- Most bought products by user
+    SELECT
+        l.title,
+        l.description,
+        l.category
+    FROM 
+        transactions.transactions t
+    JOIN
+        listings.listings l ON t.listing_id=l.id
+    WHERE
+        t.buyer_id=user_ID
+    GROUP BY
+      t.buyer_id, l.title, l.description, l.category
+    ORDER BY 
+        COUNT(t.buyer_id) DESC
+    -- Only return top 2 flavors
+    LIMIT 2;
+END;
+$$;
+

--- a/supabase/schemas/schema.sql
+++ b/supabase/schemas/schema.sql
@@ -1,7 +1,7 @@
 -- =========================
 -- 1. Profiles Schema
 -- =========================
-CREATE TABLE profiles (
+CREATE TABLE profiles(
     id uuid NOT NULL PRIMARY KEY REFERENCES auth.users ON DELETE CASCADE,
     first_name varchar(50) NOT NULL,
     last_name varchar(50) NOT NULL,
@@ -18,20 +18,20 @@ CREATE POLICY "Users can update their own profiles" ON profiles
     FOR UPDATE
         USING ((
             SELECT
-                auth.uid ()) = id)
+                auth.uid()) = id)
             WITH CHECK ((
                 SELECT
-                    auth.uid ()) = id);
+                    auth.uid()) = id);
 
-CREATE FUNCTION create_profile ()
+CREATE FUNCTION create_profile()
     RETURNS TRIGGER
     LANGUAGE plpgsql
     SECURITY DEFINER
     SET search_path = public
     AS $$
 BEGIN
-    INSERT INTO profiles (id, first_name, last_name)
-        VALUES (NEW.id, NEW.raw_user_meta_data ->> 'firstName', NEW.raw_user_meta_data ->> 'lastName');
+    INSERT INTO profiles(id, first_name, last_name)
+        VALUES(NEW.id, NEW.raw_user_meta_data ->> 'firstName', NEW.raw_user_meta_data ->> 'lastName');
     RETURN NEW;
 END;
 $$;
@@ -39,7 +39,7 @@ $$;
 CREATE TRIGGER on_auth_user_created
     AFTER INSERT ON auth.users
     FOR EACH ROW
-    EXECUTE PROCEDURE create_profile ();
+    EXECUTE PROCEDURE create_profile();
 
 -- =========================
 -- 2. Listings Schema
@@ -61,16 +61,16 @@ ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA listings GRANT ALL ON ROUTI
 
 ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA listings GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
 
-CREATE TYPE listings.category_type AS ENUM (
+CREATE TYPE listings.category_type AS ENUM(
     'chocolate',
     'fruity',
     'tropical',
     'caramel'
 );
 
-CREATE TABLE listings.listings (
+CREATE TABLE listings.listings(
     id serial,
-    seller_id uuid NOT NULL REFERENCES profiles (id) ON DELETE CASCADE,
+    seller_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
     title varchar(255) NOT NULL,
     description text,
     category listings.category_type NOT NULL,
@@ -93,22 +93,22 @@ CREATE POLICY "Users can create their own listings" ON listings.listings
     FOR INSERT
         WITH CHECK ((
             SELECT
-                auth.uid ()) = seller_id);
+                auth.uid()) = seller_id);
 
 CREATE POLICY "Users can update their own listings" ON listings.listings
     FOR UPDATE
         USING ((
             SELECT
-                auth.uid ()) = seller_id)
+                auth.uid()) = seller_id)
             WITH CHECK ((
                 SELECT
-                    auth.uid ()) = seller_id);
+                    auth.uid()) = seller_id);
 
 CREATE POLICY "Users can delete their own listings" ON listings.listings
     FOR DELETE
         USING ((
             SELECT
-                auth.uid ()) = seller_id);
+                auth.uid()) = seller_id);
 
 CREATE TABLE listings.listings_chocolate PARTITION OF listings.listings
 FOR VALUES IN ('chocolate');
@@ -123,22 +123,22 @@ CREATE POLICY "Users can create their own chocolate listings" ON listings.listin
     FOR INSERT
         WITH CHECK ((
             SELECT
-                auth.uid ()) = seller_id);
+                auth.uid()) = seller_id);
 
 CREATE POLICY "Users can update their own chocolate listings" ON listings.listings_chocolate
     FOR UPDATE
         USING ((
             SELECT
-                auth.uid ()) = seller_id)
+                auth.uid()) = seller_id)
             WITH CHECK ((
                 SELECT
-                    auth.uid ()) = seller_id);
+                    auth.uid()) = seller_id);
 
 CREATE POLICY "Users can delete their own chocolate listings" ON listings.listings_chocolate
     FOR DELETE
         USING ((
             SELECT
-                auth.uid ()) = seller_id);
+                auth.uid()) = seller_id);
 
 CREATE TABLE listings.listings_fruity PARTITION OF listings.listings
 FOR VALUES IN ('fruity');
@@ -153,22 +153,22 @@ CREATE POLICY "Users can create their own fruity listings" ON listings.listings_
     FOR INSERT
         WITH CHECK ((
             SELECT
-                auth.uid ()) = seller_id);
+                auth.uid()) = seller_id);
 
 CREATE POLICY "Users can update their own fruity listings" ON listings.listings_fruity
     FOR UPDATE
         USING ((
             SELECT
-                auth.uid ()) = seller_id)
+                auth.uid()) = seller_id)
             WITH CHECK ((
                 SELECT
-                    auth.uid ()) = seller_id);
+                    auth.uid()) = seller_id);
 
 CREATE POLICY "Users can delete their own fruity listings" ON listings.listings_fruity
     FOR DELETE
         USING ((
             SELECT
-                auth.uid ()) = seller_id);
+                auth.uid()) = seller_id);
 
 CREATE TABLE listings.listings_tropical PARTITION OF listings.listings
 FOR VALUES IN ('tropical');
@@ -183,22 +183,22 @@ CREATE POLICY "Users can create their own tropical listings" ON listings.listing
     FOR INSERT
         WITH CHECK ((
             SELECT
-                auth.uid ()) = seller_id);
+                auth.uid()) = seller_id);
 
 CREATE POLICY "Users can update their own tropical listings" ON listings.listings_tropical
     FOR UPDATE
         USING ((
             SELECT
-                auth.uid ()) = seller_id)
+                auth.uid()) = seller_id)
             WITH CHECK ((
                 SELECT
-                    auth.uid ()) = seller_id);
+                    auth.uid()) = seller_id);
 
 CREATE POLICY "Users can delete their own tropical listings" ON listings.listings_tropical
     FOR DELETE
         USING ((
             SELECT
-                auth.uid ()) = seller_id);
+                auth.uid()) = seller_id);
 
 CREATE TABLE listings.listings_caramel PARTITION OF listings.listings
 FOR VALUES IN ('caramel');
@@ -213,22 +213,22 @@ CREATE POLICY "Users can create their own caramel listings" ON listings.listings
     FOR INSERT
         WITH CHECK ((
             SELECT
-                auth.uid ()) = seller_id);
+                auth.uid()) = seller_id);
 
 CREATE POLICY "Users can update their own caramel listings" ON listings.listings_caramel
     FOR UPDATE
         USING ((
             SELECT
-                auth.uid ()) = seller_id)
+                auth.uid()) = seller_id)
             WITH CHECK ((
                 SELECT
-                    auth.uid ()) = seller_id);
+                    auth.uid()) = seller_id);
 
 CREATE POLICY "Users can delete their own caramel listings" ON listings.listings_caramel
     FOR DELETE
         USING ((
             SELECT
-                auth.uid ()) = seller_id);
+                auth.uid()) = seller_id);
 
 -- =========================
 -- 3. Transactions Schema
@@ -250,20 +250,20 @@ ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA transactions GRANT ALL ON R
 
 ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA transactions GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
 
-CREATE TABLE transactions.transactions (
+CREATE TABLE transactions.transactions(
     id serial PRIMARY KEY,
-    buyer_id uuid REFERENCES profiles (id) ON DELETE SET NULL,
-    seller_id uuid REFERENCES profiles (id) ON DELETE SET NULL,
+    buyer_id uuid REFERENCES profiles(id) ON DELETE SET NULL,
+    seller_id uuid REFERENCES profiles(id) ON DELETE SET NULL,
     listing_id int NOT NULL,
     listing_category listings.category_type NOT NULL,
-    FOREIGN KEY (listing_id, listing_category) REFERENCES listings.listings (id, category),
+    FOREIGN KEY (listing_id, listing_category) REFERENCES listings.listings(id, category),
     amount DECIMAL(10, 2) NOT NULL,
     created_at timestamp DEFAULT CURRENT_TIMESTAMP
 );
 
 ALTER TABLE transactions.transactions ENABLE ROW LEVEL SECURITY;
 
-CREATE FUNCTION transactions.purchase (listing_id int, listing_category listings.category_type)
+CREATE FUNCTION transactions.purchase(listing_id int, listing_category listings.category_type)
     RETURNS void
     AS $$
 DECLARE
@@ -274,7 +274,7 @@ DECLARE
 BEGIN
     BEGIN
         SELECT
-            auth.uid () INTO buyer_id;
+            auth.uid() INTO buyer_id;
         IF buyer_id IS NULL THEN
             RAISE EXCEPTION 'Buyer not found';
         END IF;
@@ -332,7 +332,7 @@ BEGIN
         WHERE
             id = listing_id
             AND category = listing_category;
-        INSERT INTO transactions.transactions (buyer_id, seller_id, listing_id, listing_category, amount)
+        INSERT INTO transactions.transactions(buyer_id, seller_id, listing_id, listing_category, amount)
             VALUES (buyer_id, listing_seller_id, listing_id, listing_category, listing_price);
     EXCEPTION
         WHEN OTHERS THEN
@@ -349,24 +349,24 @@ REVOKE EXECUTE ON FUNCTION transactions.purchase FROM public;
 
 REVOKE EXECUTE ON FUNCTION transactions.purchase FROM anon;
 
-CREATE TABLE transactions.deposits (
+CREATE TABLE transactions.deposits(
     id serial PRIMARY KEY,
-    user_id uuid REFERENCES profiles (id) ON DELETE SET NULL,
+    user_id uuid REFERENCES profiles(id) ON DELETE SET NULL,
     amount DECIMAL(10, 2) NOT NULL,
     created_at timestamp DEFAULT CURRENT_TIMESTAMP
 );
 
 ALTER TABLE transactions.deposits ENABLE ROW LEVEL SECURITY;
 
-CREATE FUNCTION transactions.deposit (amount DECIMAL(10, 2))
+CREATE FUNCTION transactions.deposit(amount DECIMAL(10, 2))
     RETURNS DECIMAL (
         10, 2)
     LANGUAGE plpgsql
     SECURITY DEFINER
     AS $$
 DECLARE
-    new_balance DECIMAL(10,2);
-    current_id UUID := auth.uid();
+    new_balance DECIMAL(10, 2);
+    current_id uuid := auth.uid();
 BEGIN
     UPDATE
         profiles
@@ -374,20 +374,12 @@ BEGIN
         balance = balance + amount
     WHERE
         id = current_id
-
     RETURNING
         balance INTO new_balance;
     -- update deposits table
-    INSERT INTO transactions.deposits(
-        user_id,
-        amount
-    ) VALUES (
-        current_id,
-        amount
-    );
-
-    RETURN 
-        new_balance;
+    INSERT INTO transactions.deposits(user_id, amount)
+        VALUES (current_id, amount);
+    RETURN new_balance;
 END;
 $$;
 
@@ -395,9 +387,9 @@ $$;
 ------------------ REPORT FUNCTIONS ----------------------------
 ----------------------------------------------------------------
 -- get ID , title, seller_id ,category of best selling product
-CREATE OR REPLACE FUNCTION transactions.best_selling ()
+CREATE OR REPLACE FUNCTION transactions.best_selling()
 -- Returns information about the best-selling listing
-    RETURNS TABLE (
+    RETURNS TABLE(
         id int,
         title varchar(255),
         seller_id uuid,
@@ -415,12 +407,12 @@ BEGIN
         top_sales.sales_count
     FROM
         listings.listings l
-        JOIN (
+        JOIN(
             SELECT
                 listing_id,
                 COUNT(*) AS sales_count
             FROM
-                transactions.transactions 
+                transactions.transactions
             GROUP BY
                 listing_id
             ORDER BY
@@ -434,8 +426,8 @@ END;
 $$;
 
 ----- returns id, first_name, last_name of top best selling Seller
-CREATE OR REPLACE FUNCTION transactions.Best_Selling_Seller ()
-    RETURNS TABLE (
+CREATE OR REPLACE FUNCTION transactions.Best_Selling_Seller()
+    RETURNS TABLE(
         id uuid,
         first_name varchar(50),
         last_name varchar(50),
@@ -451,7 +443,7 @@ BEGIN
         top_seller_user.sales_count
     FROM
         public.profiles p
-        JOIN (
+        JOIN(
             SELECT
                 seller_id,
                 COUNT(seller_id) AS sales_count
@@ -467,8 +459,8 @@ END;
 $$;
 
 ----- returns id, first_name, last_name of top most loyal buyer
-CREATE OR REPLACE FUNCTION transactions.Most_Loyal_Buyer ()
-    RETURNS TABLE (
+CREATE OR REPLACE FUNCTION transactions.Most_Loyal_Buyer()
+    RETURNS TABLE(
         id uuid,
         first_name varchar(50),
         last_name varchar(50),
@@ -484,7 +476,7 @@ BEGIN
         best_buyer.sales_count
     FROM
         public.profiles p
-        JOIN (
+        JOIN(
             SELECT
                 buyer_id,
                 COUNT(buyer_id) AS sales_count
@@ -501,162 +493,152 @@ $$;
 
 ---------------------------------------------------------------
 ----------------------- Per_User_Reports ----------------------
------------------Description; handles favorite flavors, 
+-----------------Description; handles favorite flavors,
 -- ---------------------------recent activity, recent transactions
 -------------------------------------------------------------------
-
-
 --------------------------------------------------------------
 ---------- RECENT TRANNSACTIONS ------------------------------
 ------------ pass user id and get his recent transactions -------
-CREATE OR REPLACE FUNCTION transactions.Recent_Transactions() 
+CREATE OR REPLACE FUNCTION transactions.Recent_Transactions()
     RETURNS TABLE(
-        transaction_type TEXT, 
-        transaction_amount DECIMAL(10,2),
+        transaction_type text,
+        transaction_amount DECIMAL(10, 2),
         transaction_date timestamp,
         -- can be null if transaction is Deposit
-        product_name VARCHAR(255)
-    )
+        product_name varchar(255))
     LANGUAGE plpgsql
     SECURITY DEFINER
     AS $$
 DECLARE
-    current_id UUID := auth.uid();
+    current_id uuid := auth.uid();
 BEGIN
     RETURN QUERY
     -- DESC: Query Bought & Sold Products by User
     SELECT
-        CASE 
-            -- bought by USER, leads to a deduction in his account balance
-            WHEN t.buyer_id = current_ID THEN 'bought'
+        CASE
+        -- bought by USER, leads to a deduction in his account balance
+        WHEN t.buyer_id = current_ID THEN
+            'bought'
             -- sold by User, leads to an addition to his acc balance
-            WHEN t.seller_id = current_ID THEN 'sold'
+        WHEN t.seller_id = current_ID THEN
+            'sold'
         END AS transaction_type,
         t.amount,
         t.created_at,
         l.title AS product_name
-    FROM 
+    FROM
         transactions.transactions t
-    JOIN
-        listings.listings l ON t.listing_id=l.id
+        JOIN listings.listings l ON t.listing_id = l.id
     WHERE
-        t.buyer_id=current_ID OR t.seller_id=current_ID
-    
+        t.buyer_id = current_ID
+        OR t.seller_id = current_ID
     UNION
     -- New Deposits by USER
     SELECT
-        'Depositted' as activity_type,
+        'Depositted' AS activity_type,
         d.amount,
         d.created_at,
         NULL AS product_name
-    FROM 
+    FROM
         transactions.deposits d
     WHERE
         d.user_id = current_ID
-
-    ORDER BY created_at DESC
-    --  can be changed to show more
+    ORDER BY
+        created_at DESC
+        --  can be changed to show more
     LIMIT 5;
 END;
 $$;
 
-
-
 ------------------------------------------------------
 ----------- RECENT ACTIVITY --------------------------
-CREATE OR REPLACE FUNCTION transactions.Recent_Activity() 
-RETURNS TABLE(
-    activity_type TEXT, 
-    activity_amount DECIMAL(10,2),
-    activity_date timestamp,
-    -- can be null if activity is Deposit
-    product_name VARCHAR(255)
-)
+CREATE OR REPLACE FUNCTION transactions.Recent_Activity()
+    RETURNS TABLE(
+        activity_type text,
+        activity_amount DECIMAL(10, 2),
+        activity_date timestamp,
+        -- can be null if activity is Deposit
+        product_name varchar(255))
     LANGUAGE plpgsql
     SECURITY DEFINER
     AS $$
 DECLARE
-    current_id UUID := auth.uid();
+    current_id uuid := auth.uid();
 BEGIN
     RETURN QUERY
-    
-    -- Recently Bought Products by User 
+    -- Recently Bought Products by User
     SELECT
         -- bought by USER, leads to a deduction in his account balance
-        'bought' as activity_type,
+        'bought' AS activity_type,
         t.amount,
         t.created_at,
         l.title AS product_name
-    FROM 
+    FROM
         transactions.transactions t
-    JOIN
-        listings.listings l ON t.listing_id=l.id
+        JOIN listings.listings l ON t.listing_id = l.id
     WHERE
         t.buyer_id = current_id
-
     UNION
     -- New Listings By User
     SELECT
-        'Added Listing' as activity_type,
+        'Added Listing' AS activity_type,
         l.price,
         l.created_at,
         l.title AS product_name
-    FROM 
+    FROM
         listings.listings l
     WHERE
         l.seller_id = current_id
-
-    UNION 
+    UNION
     -- New Deposits by USER
     SELECT
-        'Depositted' as activity_type,
+        'Depositted' AS activity_type,
         d.amount,
         d.created_at,
         NULL AS product_name
-    FROM 
+    FROM
         transactions.deposits d
     WHERE
         d.user_id = current_id
-    
-    ORDER BY created_at DESC
+    ORDER BY
+        created_at DESC
     LIMIT 5;
 END;
 $$;
 
-
 ---------------------------------------------------------------------
 ------------ Favorite Flavors ---------------------------------------
 ---------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION transactions.favorite_flavours() 
-RETURNS TABLE(
-    product_name VARCHAR(255),
-    product_description TEXT,
-    product_category listings.category_type
-)
+CREATE OR REPLACE FUNCTION transactions.favorite_flavours()
+    RETURNS TABLE(
+        product_name varchar(255),
+        product_description text,
+        product_category listings.category_type)
     LANGUAGE plpgsql
     SECURITY DEFINER
     AS $$
-DECLARE 
-    current_id UUID := auth.uid();
+DECLARE
+    current_id uuid := auth.uid();
 BEGIN
     RETURN QUERY
-    
     -- Most bought products by user
     SELECT
         l.title,
         l.description,
         l.category
-    FROM 
+    FROM
         transactions.transactions t
-    JOIN
-        listings.listings l ON t.listing_id=l.id
+        JOIN listings.listings l ON t.listing_id = l.id
     WHERE
-        t.buyer_id=current_id
+        t.buyer_id = current_id
     GROUP BY
-      t.buyer_id, l.title, l.description, l.category
-    ORDER BY 
+        t.buyer_id,
+        l.title,
+        l.description,
+        l.category
+    ORDER BY
         COUNT(t.buyer_id) DESC
-    -- Only return top 2 flavors
+        -- Only return top 2 flavors
     LIMIT 2;
 END;
 $$;

--- a/supabase/schemas/schema.sql
+++ b/supabase/schemas/schema.sql
@@ -510,13 +510,13 @@ $$;
 ---------- RECENT TRANNSACTIONS ------------------------------
 ------------ pass user id and get his recent transactions -------
 CREATE OR REPLACE FUNCTION transactions.Recent_Transactions() 
-RETURNS TABLE(
-    transaction_type TEXT, 
-    transaction_amount DECIMAL(10,2),
-    transaction_date timestamp,
-    -- can be null if transaction is Deposit
-    product_name VARCHAR(255)
-)
+    RETURNS TABLE(
+        transaction_type TEXT, 
+        transaction_amount DECIMAL(10,2),
+        transaction_date timestamp,
+        -- can be null if transaction is Deposit
+        product_name VARCHAR(255)
+    )
     LANGUAGE plpgsql
     SECURITY DEFINER
     AS $$

--- a/supabase/schemas/schema.sql
+++ b/supabase/schemas/schema.sql
@@ -552,7 +552,7 @@ $$;
 ------------------------------------------------------
 ----------- RECENT ACTIVITY --------------------------
 CREATE OR REPLACE FUNCTION transactions.Recent_Activity(
-    user_ID uuid
+    current_user_ID uuid
 ) RETURNS TABLE(
     activity_type TEXT, 
     activity_amount DECIMAL(10,2),
@@ -577,7 +577,7 @@ BEGIN
     JOIN
         listings.listings l ON t.listing_id=l.id
     WHERE
-        t.buyer_id=user_ID
+        t.buyer_id=current_user_ID
 
     UNION
     -- New Listings By User
@@ -589,8 +589,20 @@ BEGIN
     FROM 
         listings.listings l
     WHERE
-        l.seller_id=user_ID
+        l.seller_id=current_user_ID
 
+    UNION 
+    -- New Deposits by USER
+        SELECT
+        'Depositted' as activity_type,
+        d.amount,
+        d.created_at,
+        NULL AS product_name
+    FROM 
+        transactions.deposits d
+    WHERE
+        d.user_id = current_user_ID
+    
     ORDER BY created_at DESC;
 END;
 $$;

--- a/supabase/schemas/schema.sql
+++ b/supabase/schemas/schema.sql
@@ -1,7 +1,7 @@
 -- =========================
 -- 1. Profiles Schema
 -- =========================
-CREATE TABLE profiles(
+CREATE TABLE profiles (
     id uuid NOT NULL PRIMARY KEY REFERENCES auth.users ON DELETE CASCADE,
     first_name varchar(50) NOT NULL,
     last_name varchar(50) NOT NULL,
@@ -18,20 +18,20 @@ CREATE POLICY "Users can update their own profiles" ON profiles
     FOR UPDATE
         USING ((
             SELECT
-                auth.uid()) = id)
+                auth.uid ()) = id)
             WITH CHECK ((
                 SELECT
-                    auth.uid()) = id);
+                    auth.uid ()) = id);
 
-CREATE FUNCTION create_profile()
+CREATE FUNCTION create_profile ()
     RETURNS TRIGGER
     LANGUAGE plpgsql
     SECURITY DEFINER
     SET search_path = public
     AS $$
 BEGIN
-    INSERT INTO profiles(id, first_name, last_name)
-        VALUES(NEW.id, NEW.raw_user_meta_data ->> 'firstName', NEW.raw_user_meta_data ->> 'lastName');
+    INSERT INTO profiles (id, first_name, last_name)
+        VALUES (NEW.id, NEW.raw_user_meta_data ->> 'firstName', NEW.raw_user_meta_data ->> 'lastName');
     RETURN NEW;
 END;
 $$;
@@ -39,7 +39,7 @@ $$;
 CREATE TRIGGER on_auth_user_created
     AFTER INSERT ON auth.users
     FOR EACH ROW
-    EXECUTE PROCEDURE create_profile();
+    EXECUTE PROCEDURE create_profile ();
 
 -- =========================
 -- 2. Listings Schema
@@ -61,16 +61,16 @@ ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA listings GRANT ALL ON ROUTI
 
 ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA listings GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
 
-CREATE TYPE listings.category_type AS ENUM(
+CREATE TYPE listings.category_type AS ENUM (
     'chocolate',
     'fruity',
     'tropical',
     'caramel'
 );
 
-CREATE TABLE listings.listings(
+CREATE TABLE listings.listings (
     id serial,
-    seller_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    seller_id uuid NOT NULL REFERENCES profiles (id) ON DELETE CASCADE,
     title varchar(255) NOT NULL,
     description text,
     category listings.category_type NOT NULL,
@@ -93,22 +93,22 @@ CREATE POLICY "Users can create their own listings" ON listings.listings
     FOR INSERT
         WITH CHECK ((
             SELECT
-                auth.uid()) = seller_id);
+                auth.uid ()) = seller_id);
 
 CREATE POLICY "Users can update their own listings" ON listings.listings
     FOR UPDATE
         USING ((
             SELECT
-                auth.uid()) = seller_id)
+                auth.uid ()) = seller_id)
             WITH CHECK ((
                 SELECT
-                    auth.uid()) = seller_id);
+                    auth.uid ()) = seller_id);
 
 CREATE POLICY "Users can delete their own listings" ON listings.listings
     FOR DELETE
         USING ((
             SELECT
-                auth.uid()) = seller_id);
+                auth.uid ()) = seller_id);
 
 CREATE TABLE listings.listings_chocolate PARTITION OF listings.listings
 FOR VALUES IN ('chocolate');
@@ -123,22 +123,22 @@ CREATE POLICY "Users can create their own chocolate listings" ON listings.listin
     FOR INSERT
         WITH CHECK ((
             SELECT
-                auth.uid()) = seller_id);
+                auth.uid ()) = seller_id);
 
 CREATE POLICY "Users can update their own chocolate listings" ON listings.listings_chocolate
     FOR UPDATE
         USING ((
             SELECT
-                auth.uid()) = seller_id)
+                auth.uid ()) = seller_id)
             WITH CHECK ((
                 SELECT
-                    auth.uid()) = seller_id);
+                    auth.uid ()) = seller_id);
 
 CREATE POLICY "Users can delete their own chocolate listings" ON listings.listings_chocolate
     FOR DELETE
         USING ((
             SELECT
-                auth.uid()) = seller_id);
+                auth.uid ()) = seller_id);
 
 CREATE TABLE listings.listings_fruity PARTITION OF listings.listings
 FOR VALUES IN ('fruity');
@@ -153,22 +153,22 @@ CREATE POLICY "Users can create their own fruity listings" ON listings.listings_
     FOR INSERT
         WITH CHECK ((
             SELECT
-                auth.uid()) = seller_id);
+                auth.uid ()) = seller_id);
 
 CREATE POLICY "Users can update their own fruity listings" ON listings.listings_fruity
     FOR UPDATE
         USING ((
             SELECT
-                auth.uid()) = seller_id)
+                auth.uid ()) = seller_id)
             WITH CHECK ((
                 SELECT
-                    auth.uid()) = seller_id);
+                    auth.uid ()) = seller_id);
 
 CREATE POLICY "Users can delete their own fruity listings" ON listings.listings_fruity
     FOR DELETE
         USING ((
             SELECT
-                auth.uid()) = seller_id);
+                auth.uid ()) = seller_id);
 
 CREATE TABLE listings.listings_tropical PARTITION OF listings.listings
 FOR VALUES IN ('tropical');
@@ -183,22 +183,22 @@ CREATE POLICY "Users can create their own tropical listings" ON listings.listing
     FOR INSERT
         WITH CHECK ((
             SELECT
-                auth.uid()) = seller_id);
+                auth.uid ()) = seller_id);
 
 CREATE POLICY "Users can update their own tropical listings" ON listings.listings_tropical
     FOR UPDATE
         USING ((
             SELECT
-                auth.uid()) = seller_id)
+                auth.uid ()) = seller_id)
             WITH CHECK ((
                 SELECT
-                    auth.uid()) = seller_id);
+                    auth.uid ()) = seller_id);
 
 CREATE POLICY "Users can delete their own tropical listings" ON listings.listings_tropical
     FOR DELETE
         USING ((
             SELECT
-                auth.uid()) = seller_id);
+                auth.uid ()) = seller_id);
 
 CREATE TABLE listings.listings_caramel PARTITION OF listings.listings
 FOR VALUES IN ('caramel');
@@ -213,22 +213,22 @@ CREATE POLICY "Users can create their own caramel listings" ON listings.listings
     FOR INSERT
         WITH CHECK ((
             SELECT
-                auth.uid()) = seller_id);
+                auth.uid ()) = seller_id);
 
 CREATE POLICY "Users can update their own caramel listings" ON listings.listings_caramel
     FOR UPDATE
         USING ((
             SELECT
-                auth.uid()) = seller_id)
+                auth.uid ()) = seller_id)
             WITH CHECK ((
                 SELECT
-                    auth.uid()) = seller_id);
+                    auth.uid ()) = seller_id);
 
 CREATE POLICY "Users can delete their own caramel listings" ON listings.listings_caramel
     FOR DELETE
         USING ((
             SELECT
-                auth.uid()) = seller_id);
+                auth.uid ()) = seller_id);
 
 -- =========================
 -- 3. Transactions Schema
@@ -250,20 +250,20 @@ ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA transactions GRANT ALL ON R
 
 ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA transactions GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
 
-CREATE TABLE transactions.transactions(
+CREATE TABLE transactions.transactions (
     id serial PRIMARY KEY,
-    buyer_id uuid REFERENCES profiles(id) ON DELETE SET NULL,
-    seller_id uuid REFERENCES profiles(id) ON DELETE SET NULL,
+    buyer_id uuid REFERENCES profiles (id) ON DELETE SET NULL,
+    seller_id uuid REFERENCES profiles (id) ON DELETE SET NULL,
     listing_id int NOT NULL,
     listing_category listings.category_type NOT NULL,
-    FOREIGN KEY (listing_id, listing_category) REFERENCES listings.listings(id, category),
+    FOREIGN KEY (listing_id, listing_category) REFERENCES listings.listings (id, category),
     amount DECIMAL(10, 2) NOT NULL,
     created_at timestamp DEFAULT CURRENT_TIMESTAMP
 );
 
 ALTER TABLE transactions.transactions ENABLE ROW LEVEL SECURITY;
 
-CREATE FUNCTION transactions.purchase(listing_id int, listing_category listings.category_type)
+CREATE FUNCTION transactions.purchase (listing_id int, listing_category listings.category_type)
     RETURNS void
     AS $$
 DECLARE
@@ -274,7 +274,7 @@ DECLARE
 BEGIN
     BEGIN
         SELECT
-            auth.uid() INTO buyer_id;
+            auth.uid () INTO buyer_id;
         IF buyer_id IS NULL THEN
             RAISE EXCEPTION 'Buyer not found';
         END IF;
@@ -332,7 +332,7 @@ BEGIN
         WHERE
             id = listing_id
             AND category = listing_category;
-        INSERT INTO transactions.transactions(buyer_id, seller_id, listing_id, listing_category, amount)
+        INSERT INTO transactions.transactions (buyer_id, seller_id, listing_id, listing_category, amount)
             VALUES (buyer_id, listing_seller_id, listing_id, listing_category, listing_price);
     EXCEPTION
         WHEN OTHERS THEN
@@ -349,16 +349,16 @@ REVOKE EXECUTE ON FUNCTION transactions.purchase FROM public;
 
 REVOKE EXECUTE ON FUNCTION transactions.purchase FROM anon;
 
-CREATE TABLE transactions.deposits(
+CREATE TABLE transactions.deposits (
     id serial PRIMARY KEY,
-    user_id uuid REFERENCES profiles(id) ON DELETE SET NULL,
+    user_id uuid REFERENCES profiles (id) ON DELETE SET NULL,
     amount DECIMAL(10, 2) NOT NULL,
     created_at timestamp DEFAULT CURRENT_TIMESTAMP
 );
 
 ALTER TABLE transactions.deposits ENABLE ROW LEVEL SECURITY;
 
-CREATE FUNCTION transactions.deposit(amount DECIMAL(10, 2))
+CREATE FUNCTION transactions.deposit (amount DECIMAL(10, 2))
     RETURNS DECIMAL (
         10, 2)
     LANGUAGE plpgsql
@@ -366,7 +366,7 @@ CREATE FUNCTION transactions.deposit(amount DECIMAL(10, 2))
     AS $$
 DECLARE
     new_balance DECIMAL(10, 2);
-    current_id uuid := auth.uid();
+    current_id uuid := auth.uid ();
 BEGIN
     UPDATE
         profiles
@@ -377,7 +377,7 @@ BEGIN
     RETURNING
         balance INTO new_balance;
     -- update deposits table
-    INSERT INTO transactions.deposits(user_id, amount)
+    INSERT INTO transactions.deposits (user_id, amount)
         VALUES (current_id, amount);
     RETURN new_balance;
 END;
@@ -387,9 +387,9 @@ $$;
 ------------------ REPORT FUNCTIONS ----------------------------
 ----------------------------------------------------------------
 -- get ID , title, seller_id ,category of best selling product
-CREATE OR REPLACE FUNCTION transactions.best_selling()
+CREATE OR REPLACE FUNCTION transactions.best_selling ()
 -- Returns information about the best-selling listing
-    RETURNS TABLE(
+    RETURNS TABLE (
         id int,
         title varchar(255),
         seller_id uuid,
@@ -407,7 +407,7 @@ BEGIN
         top_sales.sales_count
     FROM
         listings.listings l
-        JOIN(
+        JOIN (
             SELECT
                 listing_id,
                 COUNT(*) AS sales_count
@@ -426,8 +426,8 @@ END;
 $$;
 
 ----- returns id, first_name, last_name of top best selling Seller
-CREATE OR REPLACE FUNCTION transactions.Best_Selling_Seller()
-    RETURNS TABLE(
+CREATE OR REPLACE FUNCTION transactions.Best_Selling_Seller ()
+    RETURNS TABLE (
         id uuid,
         first_name varchar(50),
         last_name varchar(50),
@@ -443,7 +443,7 @@ BEGIN
         top_seller_user.sales_count
     FROM
         public.profiles p
-        JOIN(
+        JOIN (
             SELECT
                 seller_id,
                 COUNT(seller_id) AS sales_count
@@ -459,8 +459,8 @@ END;
 $$;
 
 ----- returns id, first_name, last_name of top most loyal buyer
-CREATE OR REPLACE FUNCTION transactions.Most_Loyal_Buyer()
-    RETURNS TABLE(
+CREATE OR REPLACE FUNCTION transactions.Most_Loyal_Buyer ()
+    RETURNS TABLE (
         id uuid,
         first_name varchar(50),
         last_name varchar(50),
@@ -476,7 +476,7 @@ BEGIN
         best_buyer.sales_count
     FROM
         public.profiles p
-        JOIN(
+        JOIN (
             SELECT
                 buyer_id,
                 COUNT(buyer_id) AS sales_count
@@ -499,8 +499,8 @@ $$;
 --------------------------------------------------------------
 ---------- RECENT TRANNSACTIONS ------------------------------
 ------------ pass user id and get his recent transactions -------
-CREATE OR REPLACE FUNCTION transactions.Recent_Transactions()
-    RETURNS TABLE(
+CREATE OR REPLACE FUNCTION transactions.Recent_Transactions ()
+    RETURNS TABLE (
         transaction_type text,
         transaction_amount DECIMAL(10, 2),
         transaction_date timestamp,
@@ -510,7 +510,7 @@ CREATE OR REPLACE FUNCTION transactions.Recent_Transactions()
     SECURITY DEFINER
     AS $$
 DECLARE
-    current_id uuid := auth.uid();
+    current_id uuid := auth.uid ();
 BEGIN
     RETURN QUERY
     -- DESC: Query Bought & Sold Products by User
@@ -552,8 +552,8 @@ $$;
 
 ------------------------------------------------------
 ----------- RECENT ACTIVITY --------------------------
-CREATE OR REPLACE FUNCTION transactions.Recent_Activity()
-    RETURNS TABLE(
+CREATE OR REPLACE FUNCTION transactions.Recent_Activity ()
+    RETURNS TABLE (
         activity_type text,
         activity_amount DECIMAL(10, 2),
         activity_date timestamp,
@@ -563,7 +563,7 @@ CREATE OR REPLACE FUNCTION transactions.Recent_Activity()
     SECURITY DEFINER
     AS $$
 DECLARE
-    current_id uuid := auth.uid();
+    current_id uuid := auth.uid ();
 BEGIN
     RETURN QUERY
     -- Recently Bought Products by User
@@ -609,8 +609,8 @@ $$;
 ---------------------------------------------------------------------
 ------------ Favorite Flavors ---------------------------------------
 ---------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION transactions.favorite_flavours()
-    RETURNS TABLE(
+CREATE OR REPLACE FUNCTION transactions.favorite_flavours ()
+    RETURNS TABLE (
         product_name varchar(255),
         product_description text,
         product_category listings.category_type)
@@ -618,7 +618,7 @@ CREATE OR REPLACE FUNCTION transactions.favorite_flavours()
     SECURITY DEFINER
     AS $$
 DECLARE
-    current_id uuid := auth.uid();
+    current_id uuid := auth.uid ();
 BEGIN
     RETURN QUERY
     -- Most bought products by user

--- a/supabase/schemas/schema.sql
+++ b/supabase/schemas/schema.sql
@@ -395,7 +395,6 @@ $$;
 ------------------ REPORT FUNCTIONS ----------------------------
 ----------------------------------------------------------------
 -- get ID , title, seller_id ,category of best selling product
--- THIS IS NOT TESTED YET
 CREATE OR REPLACE FUNCTION transactions.best_selling ()
 -- Returns information about the best-selling listing
     RETURNS TABLE (

--- a/supabase/schemas/schema.sql
+++ b/supabase/schemas/schema.sql
@@ -627,15 +627,17 @@ $$;
 ---------------------------------------------------------------------
 ------------ Favorite Flavors ---------------------------------------
 ---------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION transactions.favorite_flavours(
-    user_ID uuid
-) RETURNS TABLE(
+CREATE OR REPLACE FUNCTION transactions.favorite_flavours() 
+RETURNS TABLE(
     product_name VARCHAR(255),
     product_description TEXT,
     product_category listings.category_type
 )
     LANGUAGE plpgsql
+    SECURITY DEFINER
     AS $$
+DECLARE 
+    current_id UUID := auth.uid();
 BEGIN
     RETURN QUERY
     
@@ -649,7 +651,7 @@ BEGIN
     JOIN
         listings.listings l ON t.listing_id=l.id
     WHERE
-        t.buyer_id=user_ID
+        t.buyer_id=current_id
     GROUP BY
       t.buyer_id, l.title, l.description, l.category
     ORDER BY 

--- a/supabase/schemas/schema.sql
+++ b/supabase/schemas/schema.sql
@@ -516,9 +516,9 @@ BEGIN
     -- DESC: Query Bought & Sold Products by User
     SELECT
         CASE
-        -- bought by USER, leads to a deduction in his account balance
+        -- purchase by USER, leads to a deduction in his account balance
         WHEN t.buyer_id = current_ID THEN
-            'bought'
+            'purchase'
             -- sold by User, leads to an addition to his acc balance
         WHEN t.seller_id = current_ID THEN
             'sold'
@@ -568,8 +568,8 @@ BEGIN
     RETURN QUERY
     -- Recently Bought Products by User
     SELECT
-        -- bought by USER, leads to a deduction in his account balance
-        'bought' AS activity_type,
+        -- purchase by USER, leads to a deduction in his account balance
+        'purchase' AS activity_type,
         t.amount,
         t.created_at,
         l.title AS product_name
@@ -592,7 +592,7 @@ BEGIN
     UNION
     -- New Deposits by USER
     SELECT
-        'Depositted' AS activity_type,
+        'Deposit' AS activity_type,
         d.amount,
         d.created_at,
         NULL AS product_name


### PR DESCRIPTION
## What?
Added Per User report queries
> `transactions.favorite_flavours(uuid)`; returns most bought products by User

> `transactions.recent_activity(uuid)`; takes user_id and returns recent action by user (Added Listings, bought Products, Deposits)

> `transactions.recent_transactions(uuid)`; takes user_id and returns recent transactions to user (sold products, bought Products, Deposits)

> Update `transactions.deposit(amount)` to support updating the table `transactions.deposits`

## Why?
Create user reports to be viewed on his profile and at wallet
 
## How?
Using SQL queries and the clauses JOINs, UNIONs 

## Testing?
Tested on local db after connecting it to locally hosted website

#### Favorite Flavours
![image](https://github.com/user-attachments/assets/fff87a06-82b0-4aa3-8be1-7eaedbf2c943)
I'm sure that "Tropical gdan" is his most bought product
##### Recent Transactions
![image](https://github.com/user-attachments/assets/1e70e7b9-427b-43e4-8e35-a0fddbed25d7)
Includes sold products
#### Recent Activity
![image](https://github.com/user-attachments/assets/5814cff4-459c-4a26-9767-eebb396fc10a)
Includes new listings

## Anything Else?
#### TODOS:
1. Link to UI
2. Try to show a badge "+" for deposits/sold products, "-" for bought products; for better UX so that the user is aware when his balance increased or decreased
3. For my old pull request, make dashboard route and link the reports to UI --> we can just print the reports to pdf for ease and as if ADMIN is the only one that is able to view those reports.
4. Delete settings in profile it looks ugly
![image](https://github.com/user-attachments/assets/75db268b-3db2-4242-b851-4fe5cb7d612f)
